### PR TITLE
Support replying to an ip that is not what is included in the message.

### DIFF
--- a/lib/membership.js
+++ b/lib/membership.js
@@ -85,11 +85,8 @@ Membership.prototype.onSuspect = function onSuspect(member) {
     self.onUpdate(member.data());
 };
 
-Membership.prototype.onSync = function onSync(data, host) {
-    if (data.host !== host) {
-        this.emit(Membership.EventType.Drop, data);
-        return;
-    }
+Membership.prototype.onSync = function onSync(data) {
+    var host = data.host;
 
     if (this.hostToMember[host] && this.hostToMember[host].incarnation >= data.incarnation) {
         this.swim.net.sendMessage({


### PR DESCRIPTION
It might happen that the IP from which we receive the message is not what it is included in the message. This is still valid scenario, because swim-js binds its udp socket to all server interfaces. Thus, the outgoing messages can include  in the payload a different ip address than the one contained in `rinfo`.

This PR disables this check.

More details on https://github.com/mrhooray/swim-js/issues/4#issuecomment-184402047.

Fixes #4.

