### PR TITLE
Add api documentation

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+# Do not package non-functional code when importing this package via
+# npm.
+docs/
+bench/
+test/
+.travis.yml
+.jscsrc
+.jshint.rc

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ swim.on(Swim.EventType.Error, function onError(err) {});
 swim.on(Swim.EventType.Ready, function onReady() {});
 ```
 
+[Additional API Documentation](docs/api.md)
+
 ##Benchmark
 Benchmark convergence time under different configuration
 ```sh

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,61 @@
+# API Documentation
+
+# Swim object
+
+## methods
+* constructor(options) - See Options Object.
+* boostrap(hostsToJoin, onBootStrapFunction) -
+- hostsToJoin - Addresses (with port) to try to connect to when joining the network.
+- onBootStrapFunction(err) - handler
+* whoami() - node identifier
+* members(hasLocal, hasFaulty) - gets a list of nodes in the network.
+hasLocal - nodes locally connected to this node.
+hasFaulty - nodes that are labeled suspect.
+* checksum() - ???
+
+##
+
+# Options Object
+This object contains configuration settings.
+
+## local
+* local.host (required) - address and port for this instance.  ex: localhost:11000, the
+address portion of the host entry will be used as an identifier for this node,
+while the port number portion will be the port this node will listen to for
+new connections.
+* local.meta (optional) - Additional information to add meta data about this node.  This
+will be associated with the node identification when sending messages.
+
+## codec
+encoding to send payloads.  Default msgpack.
+* json - encodes message sent between nodes as raw json.
+* msgpack - Uses msgpack, http://msgpack.org/, encoding to reduce number of
+bytes sent by the payload.
+
+##disseminationFactor
+When a node encounters an unresponsive node, it will mark that node "suspicious",
+if enough nodes mark the node as suspect, then the node is dropped form the
+network.
+
+##interval
+Number of milliseconds between failure detection intervals.  Every X
+milliseconds, nodes will ping a member of the SWIM network to check if its peer
+is still running/responding.
+
+##joinTimeout
+Number of milliseconds before emitting a JoinTimeout error.  The node will still
+run as a base node separate from the network.
+
+##pingTimout
+Average ping response time threshold, in milliseconds, for suspicion.
+
+##pingReqTimout
+Any ping response time above this threshold, in milliseconds, will mark this
+node suspicious
+
+##pingReqGroupSize
+Number of pings to use to get average response time.
+
+##udp
+UDP Options
+* maxDgramSize - max size of UDP datagram before sending.

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,8 +9,8 @@
 - onBootStrapFunction(err) - handler
 * whoami() - node identifier
 * members(hasLocal, hasFaulty) - gets a list of nodes in the network.
-hasLocal - nodes locally connected to this node.
-hasFaulty - nodes that are labeled suspect.
+hasLocal - include local/current node.
+hasFaulty - include nodes marked as faulty.
 * checksum() - ???
 
 ##
@@ -33,29 +33,36 @@ encoding to send payloads.  Default msgpack.
 bytes sent by the payload.
 
 ##disseminationFactor
-When a node encounters an unresponsive node, it will mark that node "suspicious",
-if enough nodes mark the node as suspect, then the node is dropped form the
-network.
+Dissemination factor can be used to fine tune the responsiveness of the cluster.
+Greater dissemination factor results to:
+* more hosts being notified in every round of dissemination
+* lower convergence time of cluster membership
+* more/bigger network packets being sent
+
+and vice versa.
 
 ##interval
-Number of milliseconds between failure detection intervals.  Every X
-milliseconds, nodes will ping a member of the SWIM network to check if its peer
-is still running/responding.
+Number of milliseconds between failure detections, also known as the protocol
+interval. Every X milliseconds, nodes will ping a member of the SWIM network to
+check its liveness with Time-Bounded Strong Completeness as described in the
+[paper](http://www.cs.cornell.edu/~asdas/research/dsn02-SWIM.pdf).
 
 ##joinTimeout
 Number of milliseconds before emitting a JoinTimeout error.  The node will still
 run as a base node separate from the network.
 
 ##pingTimout
-Average ping response time threshold, in milliseconds, for suspicion.
+Number of milliseconds before sending ping-req messages to the unresponsive node.
 
 ##pingReqTimout
-Any ping response time above this threshold, in milliseconds, will mark this
-node suspicious
+Number of milliseconds elapsed from sending ping-req message before marking the
+unresponsive node suspicious.
 
 ##pingReqGroupSize
-Number of pings to use to get average response time.
+Number of hosts to send ping-req messages to for pinging unresponsive nodes
+indirectly to reduce false positives.
 
 ##udp
 UDP Options
-* maxDgramSize - max size of UDP datagram before sending.
+* maxDgramSize - Max size of UDP datagram. If bigger than what the network supports,
+messages might be chunked into multiple packets and discarded at receiver end.


### PR DESCRIPTION
I created a docs folder and added the API documentation.  I figure this probably might grow as this library grows.  I also added an .npmignore file so non-functional code files will not get picked up by the npm install process.

btw, thanks for creating this library.  This attempt to document the API is so I can learn the code base better.  I want to in the future improve the suspicion protocol to allow other failure metrics beyond ping.  (for example error responses).  I think SWIM has great promise.