### PR TITLE
Do not request members ping if your ping is sucessfull

### DIFF
--- a/lib/failure-detector.js
+++ b/lib/failure-detector.js
@@ -77,6 +77,10 @@ FailureDetector.prototype.pingMember = function pingMember(member) {
         self.pingReq(member);
     }, self.pingTimeout);
 
+    self.seqToCallback[seq] = function pingAckReceiveCallback() {
+        self.clearSeq(seq);
+    };
+    
     self.swim.net.sendMessage({
         type: MessageType.Ping,
         data: {


### PR DESCRIPTION
It is asking other members to ping host even when the host respond to your ping.
I think it is not the expected behaviour.
As the numbers of hosts increased it was flaging healthy services as unhealthy.
